### PR TITLE
Add trello link to nav bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,11 @@
                         <a class="nav-link" href="https://github.com/MGFNolan/synoptic-project-resource-website" target="_blank">Source Code</a>
                     </li>
                     <li>
-                        <a class="nav-link" href="#">Contact</a>
+                        <a class="nav-link" href="https://trello.com/b/ZuGWClmM/synoptic-project-resource-library" target="_blank">Trello</a>
                     </li>
+                    <li>
+                      <a class="nav-link" href="#">Contact</a>
+                  </li>
                 </ul>
             </div>
         </nav>


### PR DESCRIPTION
I added a link in the nav bar so the Trello board is viewable.

Also worked as a practice for branches.